### PR TITLE
Adding Nerve Gardens.

### DIFF
--- a/app/(portfolio)/comics/nerveGardens/page.tsx
+++ b/app/(portfolio)/comics/nerveGardens/page.tsx
@@ -1,0 +1,12 @@
+import ContentHeader from '@/common/components/ContentHeader'
+import { nerveGardensHeader } from '@/common/constants/headerBlocks'
+
+const NerveGardens = () => {
+    return (
+        <main>
+            <ContentHeader block={nerveGardensHeader} />
+        </main>
+    )
+}
+
+export default NerveGardens

--- a/common/constants/headerBlocks.ts
+++ b/common/constants/headerBlocks.ts
@@ -10,6 +10,7 @@ import FurnitureCover from '@/public/assets/coverImages/FurnitureCover.png'
 import GlittergymCover from '@/public/assets/coverImages/GlittergymCover.png'
 import Scapes from '@/public/assets/coverImages/Scapes.png'
 import MallKingCover from '@/public/assets/coverImages/MallKingCover.png'
+import NerveGardensCover from '@/public/assets/coverImages/NerveGardensCover.png'
 import RedLightCover from '@/public/assets/coverImages/RedLightCover.png'
 import CampCover from '@/public/assets/coverImages/CampCover.png'
 
@@ -69,11 +70,20 @@ export const redLightHeader: TDescriptionBlock = {
 
 export const desertBirdsHeader: TDescriptionBlock = {
     title: 'Desert Birds',
-    subtitle: '26 pages, partial color',
+    subtitle: '26 pages, color',
     bodyText: `Illustrated by <a href="https://www.bicycleboy.net/">Jackarais</a><br/><br/>Two people try to kill each other while a talking vulture heckles them.`,
     links: externalDownloadLinks.desertBirds,
     coverImage: DesertBirdsCover,
     coverAltText: 'Desert Birds cover',
+}
+
+export const nerveGardensHeader: TDescriptionBlock = {
+    title: 'Nerve Gardens',
+    subtitle: '46 pages, color',
+    bodyText: `Illustrated by <a href="https://bsky.app/profile/jonasgoonface.bsky.social">Jonas Goonface</a><br/><br/>A company ship goes dead, hoping to drift across a restricted sector without being spotted by the eldritch AI living there.`,
+    links: externalDownloadLinks.nerveGardens,
+    coverImage: NerveGardensCover,
+    coverAltText: 'Nerve Gardens cover',
 }
 
 export const elixersHeader: TDescriptionBlock = {

--- a/common/constants/navLinks.ts
+++ b/common/constants/navLinks.ts
@@ -8,6 +8,7 @@ import ElixersCover from '@/public/assets/coverImages/ElixersCover.png'
 import FurnitureCover from '@/public/assets/coverImages/FurnitureCover.png'
 import GlittergymCover from '@/public/assets/coverImages/GlittergymCover.png'
 import MallKingCover from '@/public/assets/coverImages/MallKingCover.png'
+import NerveGardensCover from '@/public/assets/coverImages/NerveGardensCover.png'
 import RedLightCover from '@/public/assets/coverImages/RedLightCover.png'
 import CampCover from '@/public/assets/coverImages/CampCover.png'
 import WhiskersCover from '@/public/assets/coverImages/WhiskersCover.png'
@@ -24,16 +25,22 @@ const _externalLinks = {
 
 export const comicLinks: TNavLinks = [
     {
-        label: `The Curse of the Mall\xa0King`,
-        target: '/comics/mallKing',
-        previewImage: MallKingCover,
-        previewAltText: 'The Curse of the Mall King',
+        label: 'Nerve Gardens',
+        target: '/comics/nerveGardens',
+        previewImage: NerveGardensCover,
+        previewAltText: 'Nerve Gardens',
     },
     {
         label: 'Desert Birds',
         target: '/comics/desertBirds',
         previewImage: DesertBirdsCover,
         previewAltText: 'Desert Birds',
+    },
+    {
+        label: `The Curse of the Mall\xa0King`,
+        target: '/comics/mallKing',
+        previewImage: MallKingCover,
+        previewAltText: 'The Curse of the Mall King',
     },
     {
         label: 'Red Light',
@@ -105,6 +112,13 @@ export const aboutPageLinks: TNavLinks = [
 ]
 
 export const externalDownloadLinks: TExternalLinks = {
+    nerveGardens: [
+        {
+            label: 'Download',
+            target: 'https://forreststorrs.itch.io/nerve-gardens',
+            isExternal: true,
+        },
+    ],
     mallKing: [
         {
             label: 'Download',

--- a/common/types/types.ts
+++ b/common/types/types.ts
@@ -12,6 +12,7 @@ export type TNavLink = {
 export type TNavLinks = TNavLink[]
 
 export type TExternalLinks = {
+    nerveGardens: TNavLinks,
     mallKing: TNavLinks,
     achingHeights: TNavLinks,
     devyn: TNavLinks,


### PR DESCRIPTION
This PR adds a new comics page for Nerve Gardens. There is no readable comic at this time because I haven't made it free yet.